### PR TITLE
Update shadowJar info for JAR file creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,9 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveBaseName = 'BandBook'
+    archiveVersion = 'v1.2'
+    archiveClassifier = ''
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Currently, JAR files created have '-all' appended to the end of the file name (e.g BandBook-v1.2-all.jar).
Modified some lines of code so that future JAR files created do not have '-all' (e.g BandBook-v1.2.jar)