### PR TITLE
Fix issue where invalid commands words 'birthday' & 'my' were validated

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,7 +11,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AttendanceCommand;
 import seedu.address.logic.commands.AttendanceDeleteCommand;
-import seedu.address.logic.commands.BirthdayCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -21,7 +20,6 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.InstrumentCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.MatriculationYearCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -85,15 +83,8 @@ public class AddressBookParser {
         case AttendanceCommand.COMMAND_WORD:
             return new AttendanceCommandParser().parse(arguments);
 
-
         case AttendanceDeleteCommand.COMMAND_WORD:
             return new AttendanceDeleteCommandParser().parse(arguments);
-
-        case BirthdayCommand.COMMAND_WORD:
-            return new BirthdayCommandParser().parse(arguments);
-
-        case MatriculationYearCommand.COMMAND_WORD:
-            return new MatriculationYearCommandParser().parse(arguments);
 
         case InstrumentCommand.COMMAND_WORD:
             return new InstrumentCommandParser().parse(arguments);


### PR DESCRIPTION
Previously, `birthday [INDEX] b/[BIRTHDAY IN YYYY-MM-DD]` and `my [INDEX] my/[YEAR IN YYYY]` were processed as valid commands on the application, and showed users a success message after executed.
This was not the intention, and has since been removed.
'birthday' and 'my' are no longer recognized as valid commands.
Users should use `edit [INDEX] b/[BIRTHDAY IN YYYY-MM-DD]`  or `edit [INDEX] my/[YEAR IN YYYY]` to edit these fields of the selected contact.