### PR TITLE
Add data validation for birthday field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
 shadowJar {
     archiveBaseName = 'BandBook'
-    archiveVersion = 'v1.2'
+    archiveVersion = 'v1.3'
     archiveClassifier = ''
 }
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -162,6 +162,20 @@ Examples:
 
 <br>
 
+### Deleting a person/multiple people by matriculation year: `delete my/[MATRICULATION_YEAR]`
+
+Deletes all person(s) with the specified matriculation year from BandBook.
+
+Format: `delete my/[MATRICULATION_YEAR]`
+
+* Deletes the people who matriculated in year `MATRICULATION_YEAR`
+* The matriculation year specified must be in the format YYYY, and must be this year or prior.
+
+Example:
+* `delete my/2005` deletes all person(s) in BandBook who matriculated in 2005.
+
+<br>
+
 ### Marking attendance of a person/multiple people: `att`
 
 Marks the attendance of an existing person/multiple people in BandBook.
@@ -170,7 +184,13 @@ Format: `att INDEXES d/DATE`
 
 * Marks the attendance of the person(s) at the specified `INDEXES`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, ...
 * At least one index must be provided.
+* The index refers to the index number shown in the displayed person list.
 * The person's contact will be updated with a tag containing the attendance date marked.
+
+Example:
+* `list` followed by `att 1 2 d/2024-02-02` marks the attendance of the persons at the 1st and 2nd indexes of BandBook, on 2024-02-02.
+* `find David` followed by `att 1 2 d/2024-02-02` marks the attendance of the persons at the 1st and 2nd indexes of the results of the `find` command, on 2024-02-02.
+<br>
 
 ### Unmarking attendance of a person/multiple people: `attd`
 
@@ -180,8 +200,13 @@ Format: `attd INDEXES d/DATE`
 
 * Unmarks the attendance of the person(s) at the specified `INDEXES`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, ...
 * At least one index must be provided.
+* The index refers to the index number shown in the displayed person list.
 * The person must have already been marked present on the attendance date provided.
 * The person's contact will be updated with the tag containing the date specified, removed.
+
+Example:
+* `list` followed by `att 1 2 d/2024-02-02` unmarks the attendance of the persons at the 1st and 2nd indexes of BandBook, on 2024-02-02.
+* `find David` followed by `att 1 2 d/2024-02-02` unmarks the attendance of the persons at the 1st and 2nd indexes of the results of the `find` command, on 2024-02-02.
 
 <br>
 
@@ -193,6 +218,7 @@ Format: `assign INDEXES i/INSTRUMENT​`
 
 * Assigns an instrument to the person(s) at the specified `INDEXES`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one index must be provided.
+* The index refers to the index number shown in the displayed person list.
 * The instrument field will be updated with the input instrument.
 
 Examples:
@@ -261,10 +287,11 @@ Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
 **Assign**  | `assign INDEXES i/INSTRUMENT` <br> e.g. `assign 1 2 i/Flute`
-**Attendance: Mark**  | `att [INDEXES] [d/DATE_IN_YYYY-MM-DD]` e.g. `att 1 2 d/ 2024-02-02`
-**Attendance: Unmark**  | `attd [INDEXES] [d/DATE_IN_YYYY-MM-DD]` <br> e.g., `attd 1 2 d/2024-02-02`
+**Attendance: Mark**  | `att INDEXES d/DATE_IN_YYYY-MM-DD` e.g. `att 1 2 d/ 2024-02-02`
+**Attendance: Unmark**  | `attd INDEXES d/DATE_IN_YYYY-MM-DD` <br> e.g., `attd 1 2 d/2024-02-02`
 **Clear**  | `clear`
-**Delete** | `delete INDEX`<br> e.g., `delete 3`
+**Delete by INDEX** | `delete INDEX`<br> e.g., `delete 3`
+**Delete by MATRICULATION YEAR** | `delete my/MATRICULATION_YEAR` <br> e.g., `delete my/2005`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Exit**   | `exit`
 **Find**   | `find [n/KEYWORD [MORE_KEYWORDS]] [i/KEYWORD [MORE_KEYWORDS]]`<br> e.g., `find n/James Jake i/flute clarinet`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -164,6 +164,25 @@ Examples:
 
 ### Marking attendance of a person/multiple people: `att`
 
+Marks the attendance of an existing person/multiple people in BandBook.
+
+Format: `att INDEXES d/DATE`
+
+* Marks the attendance of the person(s) at the specified `INDEXES`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, ...
+* At least one index must be provided.
+* The person's contact will be updated with a tag containing the attendance date marked.
+
+### Unmarking attendance of a person/multiple people: `attd`
+
+Unmarks the attendance of an existing person/multiple people in BandBook.
+
+Format: `attd INDEXES d/DATE`
+
+* Unmarks the attendance of the person(s) at the specified `INDEXES`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, ...
+* At least one index must be provided.
+* The person must have already been marked present on the attendance date provided.
+* The person's contact will be updated with the tag containing the date specified, removed.
+
 <br>
 
 ### Assigning an instrument to a person/multiple people: `assign`
@@ -242,7 +261,8 @@ Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
 **Assign**  | `assign INDEXES i/INSTRUMENT` <br> e.g. `assign 1 2 i/Flute`
-**Attendance**  | e.g. `att 1 2 d/ 2024-02-02`
+**Attendance: Mark**  | `att [INDEXES] [d/DATE_IN_YYYY-MM-DD]` e.g. `att 1 2 d/ 2024-02-02`
+**Attendance: Unmark**  | `attd [INDEXES] [d/DATE_IN_YYYY-MM-DD]` <br> e.g., `attd 1 2 d/2024-02-02`
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -71,7 +71,7 @@ Moreover, you can **indicate and view the attendance history of your members**, 
 
 ### Viewing help : `help`
 
-Shows a message explaning how to access the help page.
+Shows a message explaining how to access the help page.
 
 ![help message](images/helpMessage.png)
 
@@ -83,7 +83,7 @@ Format: `help`
 
 Adds a person to BandBook.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [b/BIRTHDAY] [my/MATRICULATION_YEAR] [i/INSTRUMENT] [t/TAG]…​`
 
 <box type="tip" seamless>
 
@@ -109,7 +109,7 @@ Format: `list`
 
 Edits an existing person in BandBook.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [my/MATRICULATION_YEAR] [i/INSTRUMENT] [t/TAG]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -162,7 +162,7 @@ Examples:
 
 <br>
 
-### Marking attendance of a person/mulitple people: `att`
+### Marking attendance of a person/multiple people: `att`
 
 <br>
 
@@ -177,8 +177,8 @@ Format: `assign INDEXES i/INSTRUMENT​`
 * The instrument field will be updated with the input instrument.
 
 Examples:
-*  `instrument 1 i/Flute` Assigns the 1st and 2nd person with the Flute instrument.
-*  `instrument 2 3 5 i/Clarinet` Assigns the 2nd, 3rd and 5th person with the Clarinet instrument.
+*  `assign 1 i/Flute` Assigns the 1st person with the Flute instrument.
+*  `assign 2 3 5 i/Clarinet` Assigns the 2nd, 3rd and 5th person with the Clarinet instrument.
 
 <br>
 
@@ -206,7 +206,7 @@ BandBook data are saved in the hard disk automatically after any command that ch
 
 ### Editing the data file
 
-BandBook data are saved automatically as a JSON file `[JAR file location]/data/bandbook.json`. Advanced users are welcome to update data directly by editing that data file.
+BandBook data is saved automatically as a JSON file `[JAR file location]/data/bandbook.json`. Advanced users are welcome to update data directly by editing that data file.
 
 <box type="warning" seamless>
 
@@ -217,7 +217,7 @@ Furthermore, certain edits can cause the BandBook to behave in unexpected ways (
 
 <br>
 
-### Archiving data files `[coming in v2.0]`
+### View Rehearsal Schedule `[coming in v2.0]`
 
 _Details coming soon ..._
 
@@ -246,6 +246,7 @@ Action     | Format, Examples
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTHDAY] [i/INSTRUMENT] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Exit**   | `exit`
 **Find**   | `find [n/KEYWORD [MORE_KEYWORDS]] [i/KEYWORD [MORE_KEYWORDS]]`<br> e.g., `find n/James Jake i/flute clarinet`
 **List**   | `list`
 **Help**   | `help`

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -62,12 +62,15 @@ public class DeleteCommand extends Command {
         if (!this.matriculationYear.equals(new MatriculationYear(MatriculationYear.DEFAULT_MATRICULATION_YEAR))) {
             model.updateFilteredPersonList(person -> person.getMatriculationYear().equals(this.matriculationYear));
             List<Person> toDelete = new ArrayList<>(model.getFilteredPersonList());
-            toDelete.forEach(person -> {
-                model.deletePerson(person);
+            StringBuilder deletedPersonsList = new StringBuilder();
+            toDelete.forEach(personToDelete -> {
+                model.deletePerson(personToDelete);
+                deletedPersonsList.append("\n");
+                deletedPersonsList.append(Messages.format(personToDelete));
             });
 
             model.updateFilteredPersonList(person -> true);
-            return new CommandResult(String.format(MESSAGE_DELETE_PERSONS_SUCCESS, toDelete));
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSONS_SUCCESS, deletedPersonsList));
         } else {
             List<Person> lastShownList = model.getFilteredPersonList();
             if (targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/model/person/Birthday.java
+++ b/src/main/java/seedu/address/model/person/Birthday.java
@@ -34,11 +34,6 @@ public class Birthday {
      * Returns true if a given string is a valid birthday.
      */
     public static boolean isValidBirthday(String test) {
-        boolean formatIsCorrect = test.matches(VALIDATION_REGEX);
-        if (!formatIsCorrect) {
-            return false;
-        }
-
         LocalDate dateEntered;
         try {
             dateEntered = LocalDate.parse(test, DateTimeFormatter.ofPattern("yyyy-MM-dd"));

--- a/src/main/java/seedu/address/model/person/Birthday.java
+++ b/src/main/java/seedu/address/model/person/Birthday.java
@@ -3,15 +3,19 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
 /**
  * Represents a Person's birthday in the address book.
  * Guarantees: immutable; is always valid
  */
 public class Birthday {
     public static final String MESSAGE_CONSTRAINTS =
-            "Birthday should be in YYYY-MM-DD format";
+            "Birthday should be today or prior in YYYY-MM-DD format";
     public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}";
-    public static final String DEFAULT_BIRTHDAY = "9999-99-99";
+    public static final String DEFAULT_BIRTHDAY = "9999-01-01";
 
     public final String value;
 
@@ -30,7 +34,25 @@ public class Birthday {
      * Returns true if a given string is a valid birthday.
      */
     public static boolean isValidBirthday(String test) {
-        return test.matches(VALIDATION_REGEX);
+        boolean formatIsCorrect = test.matches(VALIDATION_REGEX);
+        if (!formatIsCorrect) {
+            return false;
+        }
+
+        LocalDate dateEntered;
+        try {
+            dateEntered = LocalDate.parse(test, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            LocalDate todayDate = LocalDate.now();
+            boolean dateIsValid = (dateEntered.isEqual(todayDate)) || (dateEntered.isBefore(todayDate)
+                    || test.equals(DEFAULT_BIRTHDAY));
+            if (!dateIsValid) {
+                return false;
+            }
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+
+        return true;
     }
 
     public boolean hasNoInfo() {

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -24,8 +24,8 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
-    public static final String DEFAULT_BIRTHDAY = "9999-99-99";
-    public static final String DEFAULT_MATRICULATION_YEAR = "0000";
+    public static final String DEFAULT_BIRTHDAY = Birthday.DEFAULT_BIRTHDAY;
+    public static final String DEFAULT_MATRICULATION_YEAR = MatriculationYear.DEFAULT_MATRICULATION_YEAR;
     public static final String DEFAULT_INSTRUMENT = "Flute";
 
     private Name name;


### PR DESCRIPTION
Previously, users could add any date to the birthday field, as long as it was in XXXX-XX-XX format, where X is a single digit from 0 to 9. Dates such as '2000-99-99' could be added as a valid birthday.
![before birthday validation](https://github.com/AY2324S2-CS2103T-T15-3/tp/assets/122245137/d8654b12-f4f9-48cd-89e0-20972fe09e5b)

Now, data validation has been implemented and the date must be a valid date, ranging from the same date as today (the date the user enters the data) or any date prior.
![after birthday validation](https://github.com/AY2324S2-CS2103T-T15-3/tp/assets/122245137/9a17342d-900c-4f71-83da-33e930f30325)
