### PR TITLE
Update validation regex of instrument field

### DIFF
--- a/src/main/java/seedu/address/model/person/Instrument.java
+++ b/src/main/java/seedu/address/model/person/Instrument.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Instrument {
 
     public static final String MESSAGE_CONSTRAINTS = "Instrument name should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public static final String DEFAULT_INSTRUMENT = "None";
 


### PR DESCRIPTION
This update allows the instrument field to take in more than 1 word. 

Previously, the instrument field could only take in instruments that are 1 word long:
- `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 i/Flute`
- `edit 1 i/Flute`

Currently, the instrument field can take instruments that are 2 words or more.
- `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 i/French Horn`
- `edit 1 i/French Horn`