### PR TITLE
Update with correct link to team repo status badges

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 
 # BandBook
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2324S2-CS2103T-T15-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![codecov](https://codecov.io/gh/AY2324S2-CS2103T-T15-3/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
 
 ![Ui](images/Ui.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 
 # BandBook
 
-[![CI Status](https://github.com/AY2324S2-CS2103T-T15-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/AY2324S2-CS2103T-T15-3/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2324S2-CS2103T-T15-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2324S2-CS2103T-T15-3/tp/actions)
+[![codecov](https://codecov.io/gh/AY2324S2-CS2103T-T15-3/tp/branch/master/graph/badge.svg)](https://app.codecov.io/gh/AY2324S2-CS2103T-T15-3/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Current badges lead to the correct pages when clicked, but badge appearance is still being pulled from the AB3 repo.
The updated links now reflect our repo's statuses and lead to the correct websites once clicked.