### PR TITLE
Add test cases

### DIFF
--- a/src/main/java/seedu/address/logic/commands/InstrumentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InstrumentCommand.java
@@ -35,7 +35,7 @@ public class InstrumentCommand extends Command {
             + ": Assigns an instrument to the persons identified "
             + "by the index numbers used in the last person listing. \n"
             + "Parameters: INDEXES (must be positive integers separated by a whitespace) "
-            + "i/[INSTRUMENT]\n"
+            + "i/[INSTRUMENT] (only alphanumeric characters)\n"
             + "Example: " + COMMAND_WORD + " 1 2 "
             + "i/Flute";
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Persons: %1$s";

--- a/src/main/java/seedu/address/logic/parser/InstrumentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InstrumentCommandParser.java
@@ -31,15 +31,16 @@ public class InstrumentCommandParser implements Parser<InstrumentCommand> {
         Set<Index> indexes;
         try {
             indexes = ParserUtil.parseIndexes(List.of(argMultimap.getPreamble().split(" ")));
+            String instrument = argMultimap.getValue(PREFIX_INSTRUMENT).orElse("");
+
+            return new InstrumentCommand(indexes, new Instrument(instrument));
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     InstrumentCommand.MESSAGE_USAGE), ive);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    InstrumentCommand.MESSAGE_USAGE), e);
         }
-
-
-        String instrument = argMultimap.getValue(PREFIX_INSTRUMENT).orElse("");
-
-        return new InstrumentCommand(indexes, new Instrument(instrument));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AttendanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AttendanceCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SECOND_PERSONS;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AttendanceCommand;
+
+public class AttendanceCommandParserTest {
+
+    private AttendanceCommandParser parser = new AttendanceCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAttendanceCommand() {
+        LocalDate date = LocalDate.parse("2024-03-03");
+        assertParseSuccess(parser, "1 2 d/2024-03-03", new AttendanceCommand(INDEX_FIRST_SECOND_PERSONS,
+                date));
+    }
+
+    @Test
+    public void parse_invalidIndexArg_throwsParseException() {
+        assertParseFailure(parser, "-11 d/2024-03-03", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AttendanceCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidDateArgs_throwsParseException() {
+        assertParseFailure(parser, "1 d/03-03-2024", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AttendanceCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AttendanceDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AttendanceDeleteCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SECOND_PERSONS;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AttendanceDeleteCommand;
+
+public class AttendanceDeleteCommandParserTest {
+
+    private AttendanceDeleteCommandParser parser = new AttendanceDeleteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAttendanceDeleteCommand() {
+        LocalDate date = LocalDate.parse("2024-03-03");
+        assertParseSuccess(parser, "1 2 d/2024-03-03", new AttendanceDeleteCommand(INDEX_FIRST_SECOND_PERSONS,
+                date));
+    }
+
+    @Test
+    public void parse_invalidIndexArg_throwsParseException() {
+        assertParseFailure(parser, "-11 d/2024-03-03", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AttendanceDeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidDateArgs_throwsParseException() {
+        assertParseFailure(parser, "1 d/03-03-2024", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AttendanceDeleteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/InstrumentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InstrumentCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.InstrumentCommand;
+import seedu.address.model.person.Instrument;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SECOND_PERSONS;
+
+public class InstrumentCommandParserTest {
+
+    private InstrumentCommandParser parser = new InstrumentCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsInstrumentCommand() {
+        Instrument instrument = new Instrument("flute");
+        assertParseSuccess(parser, "1 2 i/flute", new InstrumentCommand(INDEX_FIRST_SECOND_PERSONS,
+                instrument));
+    }
+
+    @Test
+    public void parse_invalidIndexArg_throwsParseException() {
+        assertParseFailure(parser, "-11 i/flute", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                InstrumentCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidInstrumentArg_throwsParseException() {
+        assertParseFailure(parser, "1 i/!!!", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                InstrumentCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/InstrumentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InstrumentCommandParserTest.java
@@ -1,13 +1,15 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.InstrumentCommand;
-import seedu.address.model.person.Instrument;
-
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SECOND_PERSONS;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.InstrumentCommand;
+import seedu.address.model.person.Instrument;
+
 
 public class InstrumentCommandParserTest {
 

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 
 /**
@@ -9,4 +11,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Set<Index> INDEX_FIRST_SECOND_PERSONS = Set.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
 }


### PR DESCRIPTION
Using non-alphanumeric characters for the instrument `assign` command now displays the appropriate error message.

![image](https://github.com/AY2324S2-CS2103T-T15-3/tp/assets/34627283/e87f2420-4833-4dad-9ba1-1e3ed1344248)



Added test cases for AttendanceCommandParser, AttendanceDeleteCommandParser and InstrumentCommandParser, increasing code coverage

Before:
 ![image](https://github.com/AY2324S2-CS2103T-T15-3/tp/assets/34627283/8eb8466e-0123-40e0-9bf9-70f85a84268b)

After: 
![image](https://github.com/AY2324S2-CS2103T-T15-3/tp/assets/34627283/97677518-eb9c-4ab6-bf91-2a3123b71637)
