### PR TITLE
Remove divider in user guide causing uneven paging

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -672,8 +672,6 @@ Action     | Format, Examples
 **List**   | `list`
 **Help**   | `help`
 
---------------------------------------------------------------------------------------------------------------------
-
 <div style="page-break-after: always;"></div>
 
 ## Glossary


### PR DESCRIPTION
Remove divider which was causing an entire blank page to be created upon exporting